### PR TITLE
chore: update env vars in custom rules examples [CFG-1165]

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ An example workflow for adding a new rule would involve:
 7. Waiting for the bundle to be published to an OCI registry
 8. Configuring a separate repo to use `snyk` together with the custom rules in this repo by configuring the following environment variables:
 ```
-export OCI_REGISTRY_URL=<OCI registry url without a protocol>
-export OCI_REGISTRY_USERNAME=<OCI registry username>
-export OCI_REGISTRY_PASSWORD=<OCI registry password>
+export SNYK_CFG_OCI_REGISTRY_URL=<OCI registry url without a protocol>
+export SNYK_CFG_OCI_REGISTRY_USERNAME=<OCI registry username>
+export SNYK_CFG_OCI_REGISTRY_PASSWORD=<OCI registry password>
 ```
 
 ## CI/CD


### PR DESCRIPTION
Required for https://snyksec.atlassian.net/browse/CFG-1165. After https://github.com/snyk/snyk/pull/2336, we can use `snyk config set` and so the environment variables now have a `SNYK_CFG_` prefix. These instructions are for CI/CD instructions in GitHub actions, where people would mostly use actual environment variables, not the `snyk config set` command.