### PR TITLE
feat: add examples for denylist

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ The example rules in this repo include:
 3. [./rules/CUSTOM-RULE-3](https://docs.snyk.io/products/snyk-infrastructure-as-code/custom-rules/getting-started-with-the-sdk/examples#example-with-logical-or): A rule using logical OR that checks if a Terraform `aws_redshift_cluster` has at least an `owner` tag or a `description` tag
 4. [./rules/CUSTOM-RULE-4](https://docs.snyk.io/products/snyk-infrastructure-as-code/custom-rules/getting-started-with-the-sdk/examples#example-with-strings): A rule using strings that checks if a Terraform `aws_redshift_cluster` has at least an `owner` tag or a `description` tag and the `owner` tag does not belong to the `@corp-domain.com` domain
 5. [./rules/CUSTOM-RULE-5](https://docs.snyk.io/products/snyk-infrastructure-as-code/custom-rules/getting-started-with-the-sdk/examples#example-with-xor): A rule using XOR that checks if a Terraform `aws_redshift_cluster` has either an `owner` tag or a `serviceDescription` tag, depending on the `type`
+6. `./rules/CUSTOM-RULE-6`: A rule using grouped resources that checks if a Kubernetes RoleBinding configuration was defined on a set of namespaces configured in a denylist
+7. [./rules/CUSTOM-RULE-7](https://docs.snyk.io/products/snyk-infrastructure-as-code/custom-rules/getting-started-with-the-sdk/examples#examples-with-grouped-resources): A rule using grouped resources that checks if a Kubernetes ConfigMap configuration contains keys located in a denylist
 
 ## Usage
 The existing rules can be:

--- a/rules/CUSTOM-RULE-6/fixtures/allowed.yaml
+++ b/rules/CUSTOM-RULE-6/fixtures/allowed.yaml
@@ -1,0 +1,9 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  namespace: mydefault
+  name: allowed
+rules:
+- apiGroups: [""]
+  resources: ["services"]
+  verbs: ["get", "watch", "list"]

--- a/rules/CUSTOM-RULE-6/fixtures/denied.yaml
+++ b/rules/CUSTOM-RULE-6/fixtures/denied.yaml
@@ -1,0 +1,9 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  namespace: kube-system
+  name: denied
+rules:
+- apiGroups: [""]
+  resources: ["services"]
+  verbs: ["get", "watch", "list"]

--- a/rules/CUSTOM-RULE-6/main.rego
+++ b/rules/CUSTOM-RULE-6/main.rego
@@ -1,0 +1,25 @@
+package rules
+
+namespace_denylist = [
+	"kube-system",
+	"default",
+]
+
+check_namespace(namespace, denylist) {
+	namespace == denylist[_]
+}
+
+deny[msg] {
+	input.kind == "RoleBinding"
+	check_namespace(input.metadata.namespace, namespace_denylist)
+	msg := {
+		"publicId": "CUSTOM-RULE-6",
+		"title": "Role grants permissions to system reserved namespace",
+		"severity": "medium",
+		"msg": "input.metadata.namespace",
+		"issue": "",
+		"impact": "",
+		"remediation": "",
+		"references": [],
+	}
+}

--- a/rules/CUSTOM-RULE-6/main_test.rego
+++ b/rules/CUSTOM-RULE-6/main_test.rego
@@ -1,0 +1,21 @@
+package rules
+
+import data.lib
+import data.lib.testing
+
+test_CUSTOM_RULE_6 {
+	# array containing test cases where the rule is allowed
+	allowed_test_cases := [{
+		"want_msgs": [],
+		"fixture": "allowed.yaml",
+	}]
+
+	# array containing cases where the rule is denied
+	denied_test_cases := [{
+		"want_msgs": ["input.metadata.namespace"],
+		"fixture": "denied.yaml",
+	}]
+
+	test_cases := array.concat(allowed_test_cases, denied_test_cases)
+	testing.evaluate_test_cases("CUSTOM-RULE-6", "./rules/CUSTOM-RULE-6/fixtures", test_cases)
+}

--- a/rules/CUSTOM-RULE-7/fixtures/allowed.yaml
+++ b/rules/CUSTOM-RULE-7/fixtures/allowed.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: allowed
+  namespace: ns
+data:
+  username: not-secret

--- a/rules/CUSTOM-RULE-7/fixtures/denied.yaml
+++ b/rules/CUSTOM-RULE-7/fixtures/denied.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: denied
+  namespace: ns
+data:
+  username: not-secret
+  password: secret

--- a/rules/CUSTOM-RULE-7/main.rego
+++ b/rules/CUSTOM-RULE-7/main.rego
@@ -1,0 +1,28 @@
+package rules
+
+sensitive_denylist := [
+	"pass",
+	"secret",
+	"key",
+	"token",
+]
+
+check_sensitive(keys, denylist) {
+	keys[key]
+	contains(key, denylist[_])
+}
+
+deny[msg] {
+	input.kind == "ConfigMap"
+	check_sensitive(input.data, sensitive_denylist)
+	msg := {
+		"publicId": "CUSTOM-RULE-7",
+		"title": "ConfigMap exposes sensitive data",
+		"severity": "high",
+		"msg": "input.data",
+		"issue": "",
+		"impact": "",
+		"remediation": "",
+		"references": [],
+	}
+}

--- a/rules/CUSTOM-RULE-7/main_test.rego
+++ b/rules/CUSTOM-RULE-7/main_test.rego
@@ -1,0 +1,21 @@
+package rules
+
+import data.lib
+import data.lib.testing
+
+test_CUSTOM_RULE_7 {
+	# array containing test cases where the rule is allowed
+	allowed_test_cases := [{
+		"want_msgs": [],
+		"fixture": "allowed.yaml",
+	}]
+
+	# array containing cases where the rule is denied
+	denied_test_cases := [{
+		"want_msgs": ["input.data"],
+		"fixture": "denied.yaml",
+	}]
+
+	test_cases := array.concat(allowed_test_cases, denied_test_cases)
+	testing.evaluate_test_cases("CUSTOM-RULE-7", "./rules/CUSTOM-RULE-7/fixtures", test_cases)
+}


### PR DESCRIPTION
This PR adds another two examples of a custom rule that can be written using `snyk-iac-rules`. These showcase how to implement denylist rules.

https://snyksec.atlassian.net/browse/CFG-1080